### PR TITLE
Fix script dir path

### DIFF
--- a/pkg/tunnel/configmap.go
+++ b/pkg/tunnel/configmap.go
@@ -23,7 +23,7 @@ sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/g' /etc/ssh/sshd_config
 sed -i 's/GatewayPorts no/GatewayPorts yes/g' /etc/ssh/sshd_config
 sed -i 's/X11Forwarding no/X11Forwarding yes/g' /etc/ssh/sshd_config
 `
-	scriptDirectory = "/config/custom-cont-init.d"
+	scriptDirectory = "/custom-cont-init.d"
 )
 
 func getConfigMap(name string) *corev1.ConfigMap {


### PR DESCRIPTION
Hi, thanks for keeping this alive!

I noticed that your fork doesn't work as intended:

```
$ kubetnl tunnel test 1080:1080
Forwarding from 127.0.0.1:41567 -> 2222
Forwarding from [::1]:41567 -> 2222
Handling connection for 41567
error: failed to listen on remote 0.0.0.0:1080: ssh: tcpip-forward request denied by peer
```

Which indicates that the `ssh-init.sh` script was never run.

The mount path is wrong, it should be mounted under `/custom-cont-init.d` 
instead of `/config/custom-cont-init.d`.

Ref:
https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers#custom-scripts
